### PR TITLE
Dockerイメージのビルドを高速化する

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,12 @@ RUN apk add --no-cache curl rtmpdump ffmpeg && \
     apk del curl
 
 ENV PATH $HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH
-COPY . /service
 WORKDIR /service
-RUN yarn
+COPY package.json yarn.lock ./
+RUN yarn --ignore-scripts
+
+COPY . .
+RUN yarn prepare
 
 RUN ln -fs /service/repo/config.yaml && \
     ln -fs /service/repo/.agserver


### PR DESCRIPTION
## What
- npmパッケージがレイヤーキャッシュされるようにしました。

Dockerfileの作成方法は、Nodeの公式ドキュメントを参考にしています。
https://nodejs.org/ja/docs/guides/nodejs-docker-webapp/

## Memo
`yarn` 実行時に自動で実行される `yarn prepare`は、 `tsc`  のコンパイルができずにエラーになるため、 `--ignore-scripts` をつけてフックされないようにし、別で`yarn prepare`を実行しています。