### PR TITLE
labelに空白文字が含まれているとエラーになっていた問題を修正

### DIFF
--- a/src/services/ag.ts
+++ b/src/services/ag.ts
@@ -9,7 +9,7 @@ export const rec = async (length: number, path: string) => {
     await mkdirp(dirname(path))
 
     await $(
-        `rtmpdump --live --rtmp ${serverUrl} --timeout 60 -B ${length} -o ${path}`,
+        `rtmpdump --live --rtmp ${serverUrl} --timeout 60 -B ${length} -o "${path}"`,
     )
     const { size } = await stat(path)
     if (!size) {

--- a/src/services/ffmpeg.ts
+++ b/src/services/ffmpeg.ts
@@ -1,5 +1,5 @@
 import { $ } from 'tish'
 
 export const extractAudio = async (videoPath: string, outputPath: string) => {
-    await $(`ffmpeg -y -i ${videoPath} -c:a copy ${outputPath}`)
+    await $(`ffmpeg -y -i "${videoPath}" -c:a copy "${outputPath}"`)
 }


### PR DESCRIPTION
## What
labelに空白文字が含まれていると、`rtmpdump` や `ffmpeg` がエラーになっていたので修正しました。